### PR TITLE
Use explicit imports

### DIFF
--- a/app/src/main/java/com/kodeco/android/coordplot/MainActivity.kt
+++ b/app/src/main/java/com/kodeco/android/coordplot/MainActivity.kt
@@ -4,7 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults


### PR DESCRIPTION
As recommended by the course leads, Android prefers to explicitly import only what's needed to ensure that you don't import "the whole world".